### PR TITLE
Hotfix for snapshotStyledComponent()

### DIFF
--- a/src/components/DirectionsButton/DirectionsButton.test.js
+++ b/src/components/DirectionsButton/DirectionsButton.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { snapshotStyledComponent } from 'helpers/helpers';
+import { snapshotStyledComponent } from 'helpers/snapshotStyledComponent';
 import DirectionsButton from './DirectionsButton';
 import renderer from 'react-test-renderer';
 

--- a/src/components/MapOverlay/MapOverlay.test.js
+++ b/src/components/MapOverlay/MapOverlay.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { snapshotStyledComponent } from 'helpers/helpers';
+import { snapshotStyledComponent } from 'helpers/snapshotStyledComponent';
 import MapOverlay from './MapOverlay';
 jest.mock('SegmentedControlIOS');
 import renderer from 'react-test-renderer';

--- a/src/components/ScheduleInfoHeader/ScheduleInfoHeader.test.js
+++ b/src/components/ScheduleInfoHeader/ScheduleInfoHeader.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { snapshotStyledComponent } from 'helpers/helpers';
+import { snapshotStyledComponent } from 'helpers/snapshotStyledComponent';
 import ScheduleInfoHeader from './ScheduleInfoHeader';
 jest.mock('SegmentedControlIOS');
 import renderer from 'react-test-renderer';

--- a/src/components/StationCard/StationCard.test.js
+++ b/src/components/StationCard/StationCard.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { snapshotStyledComponent } from 'helpers/helpers';
+import { snapshotStyledComponent } from 'helpers/snapshotStyledComponent';
 import StationCard from './StationCard';
 import renderer from 'react-test-renderer';
 

--- a/src/components/StationSlider/StationSlider.test.js
+++ b/src/components/StationSlider/StationSlider.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { snapshotStyledComponent } from 'helpers/helpers';
+import { snapshotStyledComponent } from 'helpers/snapshotStyledComponent';
 import StationSlider from './StationSlider';
 import renderer from 'react-test-renderer';
 

--- a/src/components/UnorderedList/UnorderedList.test.js
+++ b/src/components/UnorderedList/UnorderedList.test.js
@@ -1,5 +1,5 @@
 import React from 'react';
-import { snapshotStyledComponent } from 'helpers/helpers';
+import { snapshotStyledComponent } from 'helpers/snapshotStyledComponent';
 import UnorderedList from './UnorderedList';
 import renderer from 'react-test-renderer';
 

--- a/src/helpers/helpers.js
+++ b/src/helpers/helpers.js
@@ -1,7 +1,3 @@
-import React from 'react';
-import { ThemeProvider } from 'styled-components/native';
-import { COLORS } from 'assets/styles/constants';
-import renderer from 'react-test-renderer';
 import { Linking } from 'react-native';
 
 export const startNavigation = (mode, latlng) => {
@@ -22,13 +18,4 @@ export const startNavigation = (mode, latlng) => {
           .catch(err => console.error('An error occurred: ', err));
       }
     });
-};
-
-export const snapshotStyledComponent = (component) => {
-  const snapshot = renderer.create(
-    <ThemeProvider theme={COLORS}>
-      {component}
-    </ThemeProvider>
-  ).toJSON()
-  expect(snapshot).toMatchSnapshot();
 };

--- a/src/helpers/snapshotStyledComponent.js
+++ b/src/helpers/snapshotStyledComponent.js
@@ -1,0 +1,13 @@
+import React from 'react';
+import { ThemeProvider } from 'styled-components/native';
+import { COLORS } from 'assets/styles/constants';
+import renderer from 'react-test-renderer';
+
+export const snapshotStyledComponent = (component) => {
+  const snapshot = renderer.create(
+    <ThemeProvider theme={COLORS}>
+      {component}
+    </ThemeProvider>
+  ).toJSON()
+  expect(snapshot).toMatchSnapshot();
+};


### PR DESCRIPTION
`snapshotStyledComponent()` was inside a helper file that would compile with the rest of the code. This caused the app to not load in the emulator because `react-test-renderer` was being used in the rest of the code base. This fix moves it to its' own file.